### PR TITLE
Avoid blocked event bus

### DIFF
--- a/core/src/main/java/com/github/legman/EventHandler.java
+++ b/core/src/main/java/com/github/legman/EventHandler.java
@@ -156,4 +156,8 @@ class EventHandler {
             .addValue(async)
             .toString();
   }
+
+  boolean hasToBeSynchronized() {
+    return false;
+  }
 }

--- a/core/src/main/java/com/github/legman/OrderedExecutor.java
+++ b/core/src/main/java/com/github/legman/OrderedExecutor.java
@@ -1,0 +1,103 @@
+package com.github.legman;
+
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+
+class OrderedExecutor {
+
+  private static final Logger logger = LoggerFactory.getLogger(OrderedExecutor.class);
+
+  private final Executor executor;
+
+  private final Set<EventHandler> runningHandlers = new HashSet<>();
+  private final Queue<EventBus.EventWithHandler> queuedHandlers = new LinkedList<>();
+
+  OrderedExecutor(Executor executor) {
+    this.executor = executor;
+  }
+
+  void dispatchAsynchronous(final Object event, final EventHandler wrapper) {
+    if (wrapper.hasToBeSynchronized()) {
+      executeSynchronized(event, wrapper);
+    } else {
+      logger.debug("executing handler concurrently: {}", wrapper);
+      executor.execute(() -> dispatchDirectly(event, wrapper));
+    }
+  }
+
+  void dispatchDirectly(Object event, EventHandler wrapper) {
+    try {
+      wrapper.handleEvent(event);
+    } catch (InvocationTargetException e) {
+      if (wrapper.isAsync()) {
+        logger.error("could not dispatch event: {} to handler {}", event, wrapper, e);
+      } else {
+        Throwable cause = e.getCause();
+        Throwables.propagateIfPossible(cause);
+        throw new EventBusException(event, "could not dispatch event", cause);
+      }
+    }
+  }
+
+  private void executeSynchronized(final Object event, final EventHandler wrapper) {
+    synchronized (this) {
+      if (runningHandlers.contains(wrapper)) {
+        logger.debug("postponing execution of handler {}; there are already {} other handlers waiting", wrapper, queuedHandlers.size());
+        queuedHandlers.add(new EventBus.EventWithHandler(event, wrapper));
+      } else {
+        runningHandlers.add(wrapper);
+        executor.execute(() -> {
+          try {
+            dispatchDirectly(event, wrapper);
+          } finally {
+            synchronized (this) {
+              runningHandlers.remove(wrapper);
+              triggerWaitingHandlers(wrapper);
+            }
+          }
+        });
+      }
+    }
+  }
+
+  private void triggerWaitingHandlers(EventHandler wrapper) {
+    logger.debug("checking {} waiting handlers for possible execution", queuedHandlers.size());
+    for (Iterator<EventBus.EventWithHandler> iterator = queuedHandlers.iterator(); iterator.hasNext(); ) {
+      EventBus.EventWithHandler queuedHandler = iterator.next();
+      if (runningHandlers.contains(queuedHandler.handler)) {
+        logger.debug("execution of handler still waiting, because other call is still running: {}", wrapper);
+      } else {
+        logger.debug("executing postponed handler because it is no longer blocked: {}", wrapper);
+        iterator.remove();
+        executeSynchronized(queuedHandler.event, queuedHandler.handler);
+        break;
+      }
+    }
+  }
+
+  void shutdown() {
+    executor.execute(() -> {
+      synchronized (this) {
+        if (queuedHandlers.isEmpty()) {
+          logger.debug("no more handlers queued; shutting down executors");
+          if (executor instanceof ExecutorService) {
+            ((ExecutorService) executor).shutdown();
+          }
+        } else {
+          logger.debug("queued handlers found; postponing shutdown");
+          shutdown();
+        }
+      }
+    });
+  }
+}

--- a/core/src/main/java/com/github/legman/SynchronizedEventHandler.java
+++ b/core/src/main/java/com/github/legman/SynchronizedEventHandler.java
@@ -46,11 +46,6 @@ final class SynchronizedEventHandler extends EventHandler {
   }
 
   @Override
-  public void handleEvent(Object event) throws InvocationTargetException {
-    super.handleEvent(event);
-  }
-
-  @Override
   boolean hasToBeSynchronized() {
     return true;
   }

--- a/core/src/main/java/com/github/legman/SynchronizedEventHandler.java
+++ b/core/src/main/java/com/github/legman/SynchronizedEventHandler.java
@@ -52,4 +52,9 @@ final class SynchronizedEventHandler extends EventHandler {
       super.handleEvent(event);
     }
   }
+
+  @Override
+  boolean hasToBeSynchronized() {
+    return true;
+  }
 }

--- a/core/src/main/java/com/github/legman/SynchronizedEventHandler.java
+++ b/core/src/main/java/com/github/legman/SynchronizedEventHandler.java
@@ -47,10 +47,7 @@ final class SynchronizedEventHandler extends EventHandler {
 
   @Override
   public void handleEvent(Object event) throws InvocationTargetException {
-    // https://code.google.com/p/guava-libraries/issues/detail?id=1403
-    synchronized (this) {
-      super.handleEvent(event);
-    }
+    super.handleEvent(event);
   }
 
   @Override

--- a/core/src/test/java/com/github/legman/EventBusTest.java
+++ b/core/src/test/java/com/github/legman/EventBusTest.java
@@ -118,28 +118,6 @@ class EventBusTest {
   }
 
   @Test
-  void testConcurrentExecution() {
-    EventBus bus = new EventBus();
-    ConcurrentListener concurrentListener = new ConcurrentListener();
-    bus.register(concurrentListener);
-    bus.post("event");
-    bus.post("event");
-    bus.post("event");
-    assertThat(concurrentListener.concurrentAccessDetected).isTrue();
-  }
-
-  @Test
-  void testNonConcurrentExecution() {
-    EventBus bus = new EventBus();
-    NonConcurrentListener concurrentListener = new NonConcurrentListener();
-    bus.register(concurrentListener);
-    bus.post("event");
-    bus.post("event");
-    bus.post("event");
-    assertThat(concurrentListener.concurrentAccessDetected).isFalse();
-  }
-
-  @Test
   void testThreadName() throws InterruptedException {
     EventBus bus = new EventBus("hansolo");
     ThreadNameTestListener listener = new ThreadNameTestListener();
@@ -177,6 +155,28 @@ class EventBusTest {
     assertThat(listener.event).isNull();
     Thread.sleep(500L);
     assertThat(listener.event).isNull();
+  }
+
+  @Test
+  void testConcurrentExecution() {
+    EventBus bus = new EventBus();
+    ConcurrentListener concurrentListener = new ConcurrentListener();
+    bus.register(concurrentListener);
+    bus.post("event");
+    bus.post("event");
+    bus.post("event");
+    assertThat(concurrentListener.concurrentAccessDetected).isTrue();
+  }
+
+  @Test
+  void testNonConcurrentExecution() {
+    EventBus bus = new EventBus();
+    NonConcurrentListener concurrentListener = new NonConcurrentListener();
+    bus.register(concurrentListener);
+    bus.post("event");
+    bus.post("event");
+    bus.post("event");
+    assertThat(concurrentListener.concurrentAccessDetected).isFalse();
   }
 
   @Test
@@ -255,6 +255,32 @@ class EventBusTest {
     }
   }
 
+  private static class SyncListener {
+
+    private String event;
+
+    @Subscribe(async = false)
+    public void handleEvent(String event) {
+      this.event = event;
+    }
+  }
+
+  private class StrongListener {
+
+    @Subscribe(async = false, referenceType = ReferenceType.STRONG)
+    public void handleEvent(String event) {
+      strongReferenceTest = event;
+    }
+  }
+
+  private class WeakListener {
+
+    @Subscribe(async = false)
+    public void handleEvent(String event) {
+      weakReferenceTest = event;
+    }
+  }
+
   private static class ConcurrentListener {
 
     private final AtomicInteger currentAccessCount = new AtomicInteger(0);
@@ -282,32 +308,6 @@ class EventBusTest {
       }
       Thread.sleep(1000);
       currentAccessCount.decrementAndGet();
-    }
-  }
-
-  private static class SyncListener {
-
-    private String event;
-
-    @Subscribe(async = false)
-    public void handleEvent(String event) {
-      this.event = event;
-    }
-  }
-
-  private class StrongListener {
-
-    @Subscribe(async = false, referenceType = ReferenceType.STRONG)
-    public void handleEvent(String event) {
-      strongReferenceTest = event;
-    }
-  }
-
-  private class WeakListener {
-
-    @Subscribe(async = false)
-    public void handleEvent(String event) {
-      weakReferenceTest = event;
     }
   }
 


### PR DESCRIPTION
## Proposed changes

The old synchronization of asynchronous non-concurrent event handlers could lead to a blocked event bus with a single long-running event handler. For this to happen, the following situation had to occur:

1. A event had to be thrown and a (asynchronous non-concurrent) handler has to take some time to process this event
2. During this processing more events have to be thrown that have to be handled by this blocked event handler.

In this case, the handling of the following events are blocked by the synchronization in the `SynchronizedEventHandler` class until the first event has been processed completely. Because the synchonization happens in the `handleEvent` method inside the handler, this blocks a thread of the executor per event, until all threads are blocked an therefore no more asynchronous events whatsoever can be processed any more.

To avoid such situations, the synchronization is now done outside of the executor and its threads. To do so, the new class `ExecutorSerializer` is introduced. This class can be seen as a steward, that blocks events for event handlers, whenever a event handler of the same type is already queued in the executor to process another event. The waiting event is put in a queue outside the executor an will be taken into account again, whenever the first process has finished.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
