### PR TITLE
Prevent ConcurrentModificationExceptions

### DIFF
--- a/core/src/main/java/com/github/legman/EventBus.java
+++ b/core/src/main/java/com/github/legman/EventBus.java
@@ -49,6 +49,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
 
 
 /**
@@ -136,7 +137,7 @@ public class EventBus {
    * made after acquiring a read or write lock via {@link #handlersByTypeLock}.
    */
   @VisibleForTesting
-  final SetMultimap<Class<?>, EventHandler> handlersByType = HashMultimap.create();
+  final SetMultimap<Class<?>, EventHandler> handlersByType = synchronizedSetMultimap(HashMultimap.create());
 
   private final ReadWriteLock handlersByTypeLock = new ReentrantReadWriteLock();
 


### PR DESCRIPTION
## Proposed changes

On heavier loads, the log of SCM-Manager has been
flooded with ConcurrentModificationException like this:

```
Exception in thread "ScmEventBus-1-691" java.util.ConcurrentModificationException at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1511) at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1534) at com.google.common.collect.AbstractMapBasedMultimap$Itr.next(AbstractMapBasedMultimap.java:1150) at com.github.legman.EventBus.removeEventHandler(EventBus.java:272) at com.github.legman.EventHandler.handleEvent(EventHandler.java:105) at com.github.legman.SynchronizedEventHandler.handleEvent(SynchronizedEventHandler.java:52) at com.github.legman.EventBus.dispatchSynchronous(EventBus.java:452) at com.github.legman.EventBus.lambda$dispatch$1(EventBus.java:444) at org.apache.shiro.subject.support.SubjectRunnable.doRun(SubjectRunnable.java:120) at org.apache.shiro.subject.support.SubjectRunnable.run(SubjectRunnable.java:108) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) at java.base/java.lang.Thread.run(Thread.java:829)
```

To avoid this, the handlersByType map now is synchronized.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
