### PR TITLE
Fix legman binding to micrometer

### DIFF
--- a/support/micrometer/pom.xml
+++ b/support/micrometer/pom.xml
@@ -26,7 +26,19 @@
       <artifactId>micrometer-core</artifactId>
       <version>1.6.5</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
+      <version>1.7.0</version>
+      <scope>compile</scope>
+    </dependency>
 
+    <dependency>
+      <groupId>com.github.sdorra</groupId>
+      <artifactId>junit-shiro-extension</artifactId>
+      <version>1.0.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Unwrap executor service while binding with micrometer because the Shiro's SubjectAwareExecutorService is not supported.
